### PR TITLE
MAINT: Bump with audit fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,6 @@ customization options.
 ## Contributing
 
 Make sure you have done `npm install` to get all dependencies and used
-`ncc build index.js` before committing and opening a PR.
+`ncc build index.js` before committing and opening a PR. On Ubuntu you might
+need to `export NODE_OPTIONS=--openssl-legacy-provider` before the `ncc build`
+step.


### PR DESCRIPTION
Locally I used:
```bash
npm audit fix
npm install
ncc build index.js
```
and committed the result. It produced the same changes as in #51 and #52 plus a little bit more, which I'm adding here.