### PR TITLE
ENH: Use version for autofix-ci and add automerge

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,4 +24,4 @@ jobs:
       - run: ncc build index.js
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
-      - uses: autofix-ci/action@v1.3.1
+      - uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944  # v1.3.1

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,4 +24,4 @@ jobs:
       - run: ncc build index.js
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
-      - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
+      - uses: autofix-ci/action@v1.3.1

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,18 @@
+# Adapted from MNE-Python
+name: Bot auto-merge
+on: pull_request  # yamllint disable-line rule:truthy
+
+jobs:
+  autobot:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    # Names can be found with gh api /repos/mne-tools/mne-python/pulls/12998 -q .user.login for example
+    if: (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' || github.event.pull_request.user.login == 'github-actions[bot]') && github.repository == 'scientific-python/circleci-artifacts-redirector-action'
+    steps:
+      - name: Enable auto-merge for bot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
@bsipocz feel free to merge if you're happy

1. Adds version for autofix-ci
2. Adds automerge for dependabot PRs (and pre-commit PRs if we have them eventually)

(2) has saved me a lot of time in other repos when dependabot opens PRs. I added branch protection rules to make sure the status update passes and that CircleCI passes, which should hopefully be enough. And in any rare case where it's not, it's easy enough to revert a merged PR.