### PR TITLE
Add option to set CircleCI domain

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   job-title:
     description: 'The name of the job, as it will render on the PR GUI (default is "<name of CI job> artifact)"'
     required: false
+  domain:
+    description: 'The domain on which CircleCI artifacts are hosted. Defaults to output.circle-artifacts.com.'
+    required: false
+    default: 'output.circle-artifacts.com'
 outputs:
   url:
     description: 'The full redirect URL'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,13 @@ inputs:
     description: 'The name of the job, as it will render on the PR GUI (default is "<name of CI job> artifact)"'
     required: false
   domain:
-    description: 'The domain on which CircleCI artifacts are hosted. Defaults to output.circle-artifacts.com.'
+    description: |
+      The domain on which CircleCI artifacts are hosted. Defaults to
+      output.circle-artifacts.com.
+
+      Can, e.g., be set to use the Scientific Python CircleCI
+      proxy (https://github.com/scientific-python/circleci-proxy),
+      which addresses some routing issues.
     required: false
     default: 'output.circle-artifacts.com'
 outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -35154,6 +35154,9 @@ async function run() {
     else {
       url = payload.target_url;
     }
+    // Set root domain
+    var domain = core.getInput('domain')
+    url = `https://${domain}/output/${url.split('/output/')[1]}`
     core.debug(`Linking to: ${url}`)
     core.debug((new Date()).toTimeString())
     core.setOutput("url", url)

--- a/index.js
+++ b/index.js
@@ -66,6 +66,9 @@ async function run() {
     else {
       url = payload.target_url;
     }
+    // Set root domain
+    var domain = core.getInput('domain')
+    url = `https://${domain}/output/${url.split('/output/')[1]}`
     core.debug(`Linking to: ${url}`)
     core.debug((new Date()).toTimeString())
     core.setOutput("url", url)


### PR DESCRIPTION
This is in support of using our new CircleCI proxy at https://circle.scientific-python.dev

See motivation at https://github.com/scientific-python/circleci-proxy

I do not know how to test the modifications I made here :thinking: @larsoner?

EDIT: Well, the fact that I managed to break the action, observe the breakage, and fix it again makes me feel more confident :)

EDIT: I've confirmed that this works by using it in https://github.com/stefanv/myst-preview/pull/2