### PR TITLE
DOC: add the 'domain' option to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ GitHub Action to add a GitHub status link to a CircleCI artifact.
 
 ## Example usage
 
-Sample `.github/workflows/main.yml`:
-
 ```YAML
 on: [status]
 
@@ -28,6 +26,7 @@ jobs:
           artifact-path: 0/test_artifacts/root_artifact.md
           circleci-jobs: build_doc
           job-title: Check the rendered docs here!
+          domain: output.circle-artifacts.com  # or a proxy address to work around routing issues
       - name: Check the URL
         if: github.event.status != 'pending'
         run: |
@@ -57,6 +56,9 @@ jobs:
 - The `job-title` corresponds to the name of the action job as it will appear
   on github. It is **not** the circle-ci job you want the artifacts for
   (this is `circleci-jobs`). This field is optional.
+- Use `domain` to set where the CircleCI artifacts are hosted. It defaults to CircleCI, but the
+  [Scientific Python CircleCI proxy](https://github.com/scientific-python/circleci-proxy) can be set, too,
+  as it addresses some routing issues for mystmd generated outputs.
 - The action has an outtput ``url`` that you can use in downstream steps, but
   this URL will only point to a valid artifact once the job is complete, i.e.,
   `github.event.status` is either `'success'`, `'fail'`, or (maybe) `'error'`,


### PR DESCRIPTION
I tagged the release before noticing the docs didn't end up in the README page. (Also did a minor cleanup as things got renamed, but then I don't see much sense in referring to the status.yml in the readme)