### PR TITLE
Removed the headers argument passed to 'fetch' in step one

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35863,8 +35863,7 @@ async function run() {
 
       // 1. Get the jobs that belong to this workflow
       const jobsRes = await fetch(
-        `https://circleci.com/api/v2/workflow/${workflowId}/job`,
-        { headers: { 'Circle-Token': apiToken } }
+        `https://circleci.com/api/v2/workflow/${workflowId}/job`
       );
       const jobs = await jobsRes.json();
       if (!jobs.items.length) {

--- a/index.js
+++ b/index.js
@@ -46,8 +46,7 @@ async function run() {
 
       // 1. Get the jobs that belong to this workflow
       const jobsRes = await fetch(
-        `https://circleci.com/api/v2/workflow/${workflowId}/job`,
-        {  }
+        `https://circleci.com/api/v2/workflow/${workflowId}/job`
       );
       const jobs = await jobsRes.json();
       if (!jobs.items.length) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ async function run() {
       // 1. Get the jobs that belong to this workflow
       const jobsRes = await fetch(
         `https://circleci.com/api/v2/workflow/${workflowId}/job`,
-        { headers: { 'Circle-Token': apiToken } }
+        {  }
       );
       const jobs = await jobsRes.json();
       if (!jobs.items.length) {


### PR DESCRIPTION
Originally the api token was being passed to fetch in step one, where the workflow is being polled for job information, which seems to result in 401 errors.

The URL being constructed for that section can be examined without the API token, so I stopped the header being passed to that fetch, and my problem (which I misdiagnosed in issue #83) is now fixed.

Closes #83